### PR TITLE
Set locale Variable to reflect User Language

### DIFF
--- a/gateways/stripe/script.js
+++ b/gateways/stripe/script.js
@@ -14,6 +14,7 @@
 
             var stripeHandler = StripeCheckout.configure({
                 key: ShoppingCart.settings.payment.methods.stripe.publicKey,
+                locale: 'auto',
                 token: function(token, args) {
                     var order = {
                         products: storejs.get('grav-shoppingcart-basket-data'),


### PR DESCRIPTION
The Stripe settings didn't take the locale variable into account. The Checkout Form was always in english. This fixes it! In my case it's german now.